### PR TITLE
Make load() no longer bypasses the config

### DIFF
--- a/src/main/java/com/github/yuttyann/scriptblockplus/Updater.java
+++ b/src/main/java/com/github/yuttyann/scriptblockplus/Updater.java
@@ -67,6 +67,10 @@ public final class Updater {
 	}
 
 	public void load() throws Exception {
+		if(!SBConfig.UPDATE_CHECKER.getValue()){
+		    isUpperVersion = false;
+		    return;
+		}
 		NodeList rootChildren = getDocument(pluginName).getDocumentElement().getChildNodes();
 		for (int i = 0; i < rootChildren.getLength(); i++) {
 			Node uNode = rootChildren.item(i);


### PR DESCRIPTION
> When accessing name.xml, it ignores the configuration file.

It should be a mistake and in some cases it will pause the server, when the server is not able to access the site ```xml.yuttyann44581.net```.
It should be controlled by the configuration so the plugin can still work well in those cases.
Thanks. I'm not very understand in your PR rules and the modifies not been tested, so it just a suggestion.